### PR TITLE
chore(ENG-40447) Silence the depreciated feature warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,8 +27,15 @@ locals {
 
   generated_tags = { for l in keys(local.id_context) : title(l) => local.id_context[l] if length(local.id_context[l]) > 0 }
 
-  tags                 = merge(var.context.tags, local.generated_tags, var.tags)
-  tags_as_list_of_maps = data.null_data_source.tags_as_list_of_maps.*.outputs
+  tags = merge(var.context.tags, local.generated_tags, var.tags)
+  
+  tags_as_list_of_maps = flatten([
+    for key in keys(local.tags) : merge(
+      {
+        key   = key
+        value = local.tags[key]
+    }, local.additional_tag_map)
+  ])
 
   id_context = {
     name        = local.name
@@ -59,10 +66,8 @@ locals {
 
 }
 
-data "null_data_source" "tags_as_list_of_maps" {
-  count = local.enabled ? length(keys(local.tags)) : 0
-
-  inputs = merge(
+locals {
+  tags_as_list_of_maps = merge(
     {
       "key"   = element(keys(local.tags), count.index)
       "value" = element(values(local.tags), count.index)

--- a/main.tf
+++ b/main.tf
@@ -65,13 +65,3 @@ locals {
   }
 
 }
-
-locals {
-  tags_as_list_of_maps = merge(
-    {
-      "key"   = element(keys(local.tags), count.index)
-      "value" = element(values(local.tags), count.index)
-    },
-    var.additional_tag_map,
-  )
-}

--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,0 @@
-provider "null" {
-  version = ">= 2.1"
-}
-

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,4 +1,8 @@
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws  = ">= 2.1"
+  }  
 }
 


### PR DESCRIPTION
* To silence the depreciated warnings below:


│ Warning: Deprecated
│
│   with module.msk_label.data.null_data_source.tags_as_list_of_maps,
│   on .terraform/modules/msk_label/main.tf line 62, in data "null_data_source" "tags_as_list_of_maps":
│   62: data "null_data_source" "tags_as_list_of_maps" {
│
│ The null_data_source was historically used to construct intermediate values to re-use elsewhere in configuration, the same can now be achieved using locals
│
│ (and 3 more similar warnings elsewhere)
╵
╷
│ Warning: Version constraints inside provider configuration blocks are deprecated
│
│   on .terraform/modules/msk_label/provider.tf line 2, in provider "null":
│    2:   version = ">= 2.1"
│
│ Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future version of
│ Terraform. To silence this warning, move the provider version constraint into the required_providers block.
╵